### PR TITLE
Refactor path-operations and override-dispatch internals

### DIFF
--- a/source/main.ts
+++ b/source/main.ts
@@ -113,23 +113,16 @@ function isFactory<T extends Record<string, AllowedObjectShapeValues>>(value: un
     return isRecord(value) && typeof value.build === 'function';
 }
 
-type ArrayFactoryMarker = { [arrayFactorySymbol]?: boolean };
-
 function isArrayFactoryValue(value: unknown): value is ArrayFactoryValue<Record<string, AllowedObjectShapeValues>> {
     if (!isRecord(value)) {
         return false;
     }
 
-    const marker = value as ArrayFactoryMarker;
-
-    if (marker[arrayFactorySymbol] !== true) {
+    if (value[arrayFactorySymbol] !== true) {
         return false;
     }
 
-    const maybeFactory = (value as { factory?: unknown }).factory;
-    const maybeLength = (value as { length?: unknown }).length;
-
-    return isFactory(maybeFactory) && typeof maybeLength === 'number';
+    return isFactory(value.factory) && typeof value.length === 'number';
 }
 
 function isPrimitiveAllowedObjectShapeValue(value: unknown): boolean {
@@ -199,7 +192,7 @@ function createOverrideWrapper(value: unknown): OverrideWrapper {
 }
 
 function isOverrideWrapper(value: unknown): value is OverrideWrapper {
-    return isRecord(value) && (value as Partial<OverrideWrapper>)[overrideWrapperSymbol] === true;
+    return isRecord(value) && value[overrideWrapperSymbol] === true;
 }
 
 function createRemovePropertySentinel(): RemoveProperty {
@@ -208,12 +201,26 @@ function createRemovePropertySentinel(): RemoveProperty {
     };
 }
 
-// eslint-disable-next-line max-statements, complexity -- needs to be refactored
-function prepareOverrideValue(value: unknown, nested = false): unknown {
+function mapRecordEntries(
+    record: Record<PropertyKey, unknown>,
+    mapValue: (child: unknown) => unknown
+): Record<string, unknown> {
+    const prepared: Record<string, unknown> = {};
+
+    for (const [key, child] of Object.entries(record)) {
+        prepared[key] = mapValue(child);
+    }
+
+    return prepared;
+}
+
+function prepareNestedOverrideValue(value: unknown): unknown {
+    if (value === undefined) {
+        return createRemovePropertySentinel();
+    }
+
     if (Array.isArray(value)) {
-        return value.map((item) => {
-            return prepareOverrideValue(item, true);
-        });
+        return value.map(prepareNestedOverrideValue);
     }
 
     if (value instanceof Date) {
@@ -221,28 +228,32 @@ function prepareOverrideValue(value: unknown, nested = false): unknown {
     }
 
     if (isRecord(value)) {
-        const prepared: Record<string, unknown> = {};
-
-        for (const [nestedKey, nestedValue] of Object.entries(value)) {
-            if (nestedValue === undefined) {
-                prepared[nestedKey] = nested ? createRemovePropertySentinel() : undefined;
-            } else {
-                prepared[nestedKey] = prepareOverrideValue(nestedValue, true);
-            }
-        }
-
-        return prepared;
+        return mapRecordEntries(value, prepareNestedOverrideValue);
     }
 
-    if (nested && value === undefined) {
-        return createRemovePropertySentinel();
+    return value;
+}
+
+function prepareOverrideValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(prepareNestedOverrideValue);
+    }
+
+    if (value instanceof Date) {
+        return value;
+    }
+
+    if (isRecord(value)) {
+        return mapRecordEntries(value, (child) => {
+            return child === undefined ? undefined : prepareNestedOverrideValue(child);
+        });
     }
 
     return value;
 }
 
 function isRemoveProperty(value: unknown): value is RemoveProperty {
-    return isRecord(value) && (value as Partial<RemoveProperty>)[removePropertySymbol] === true;
+    return isRecord(value) && value[removePropertySymbol] === true;
 }
 
 function isNoOverride(override: unknown): override is typeof noOverrideSymbol {
@@ -324,9 +335,9 @@ function materializeTemplateArray(
     });
 }
 
-function materializeFactoryWithOverride(
-    value: ObjectoryFactory<Record<string, AllowedObjectShapeValues>>,
-    override: NormalizedOverride
+function withMaterializedOverride(
+    override: NormalizedOverride,
+    materialize: (overrideValue: unknown) => AllowedObjectShapeValues
 ): AllowedObjectShapeValues | RemoveProperty {
     if (override.applied && isRemoveProperty(override.value)) {
         return override.value;
@@ -334,26 +345,25 @@ function materializeFactoryWithOverride(
 
     const resolvedOverride = override.applied ? override.value : undefined;
 
-    return buildFactoryValue(value, resolvedOverride);
+    return materialize(resolvedOverride);
+}
+
+function materializeFactoryWithOverride(
+    value: ObjectoryFactory<Record<string, AllowedObjectShapeValues>>,
+    override: NormalizedOverride
+): AllowedObjectShapeValues | RemoveProperty {
+    return withMaterializedOverride(override, (resolved) => {
+        return buildFactoryValue(value, resolved);
+    });
 }
 
 function materializeArrayFactoryWithOverride(
     value: ArrayFactoryValue<Record<string, AllowedObjectShapeValues>>,
     override: NormalizedOverride
 ): AllowedObjectShapeValues | RemoveProperty {
-    if (!override.applied) {
-        return materializeArrayFactoryValue(value, undefined);
-    }
-
-    if (isRemoveProperty(override.value)) {
-        return override.value;
-    }
-
-    if (override.value === undefined) {
-        return materializeArrayFactoryValue(value, undefined);
-    }
-
-    return materializeArrayFactoryValue(value, override.value);
+    return withMaterializedOverride(override, (resolved) => {
+        return materializeArrayFactoryValue(value, resolved);
+    });
 }
 
 function materializeTemplateWithOverride(
@@ -361,19 +371,9 @@ function materializeTemplateWithOverride(
     override: NormalizedOverride,
     resolve: (value: AllowedGeneratorReturnShape, overrideValue: unknown) => AllowedObjectShapeValues
 ): AllowedObjectShapeValues | RemoveProperty {
-    if (!override.applied) {
-        return materializeTemplateArray(value, undefined, resolve);
-    }
-
-    if (isRemoveProperty(override.value)) {
-        return override.value;
-    }
-
-    if (override.value === undefined) {
-        return materializeTemplateArray(value, undefined, resolve);
-    }
-
-    return materializeTemplateArray(value, override.value, resolve);
+    return withMaterializedOverride(override, (resolved) => {
+        return materializeTemplateArray(value, resolved, resolve);
+    });
 }
 
 function materializeLeafValue(

--- a/source/path-operations.ts
+++ b/source/path-operations.ts
@@ -4,34 +4,15 @@ export type PathSegment = number | string;
 
 type Path = readonly PathSegment[];
 
+const integerSegmentPattern = /^\d+$/u;
+
 export function normalizePath(path: string): Path {
     return path.split('.').map((segment) => {
-        const segmentAsNumber = Number.parseInt(segment, 10);
-        if (!Number.isNaN(segmentAsNumber)) {
-            return segmentAsNumber;
+        if (integerSegmentPattern.test(segment)) {
+            return Number(segment);
         }
         return segment;
     });
-}
-
-function removeFromArray(target: readonly unknown[], pathSegments: Path): unknown[] {
-    const [head, ...tail] = pathSegments;
-    const index = typeof head === 'number' ? head : Number(head);
-
-    if (!Number.isInteger(index) || index < 0 || index >= target.length) {
-        return target.slice();
-    }
-
-    const copy = target.slice();
-
-    if (tail.length === 0) {
-        copy.splice(index, 1);
-        return copy;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- ok for recursive call
-    copy[index] = removePropertyAtPath(copy[index], tail);
-    return copy;
 }
 
 function toKey(segment: PathSegment): string {
@@ -47,65 +28,16 @@ function removeDirectKey(target: Record<string, unknown>, key: string): Record<s
     return rest;
 }
 
-function updateNestedKey(
-    target: Record<string, unknown>,
-    key: string,
-    tail: readonly PathSegment[]
-): Record<string, unknown> {
-    const current = target[key];
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- ok for recursive call
-    const updated = removePropertyAtPath(current, tail);
+type ArrayTerminal = (copy: unknown[], index: number) => unknown[];
+type ObjectTerminal = (target: Record<string, unknown>, key: string) => Record<string, unknown>;
+type RecursiveStep = (child: unknown, tail: Path) => unknown;
 
-    if (updated === current) {
-        return shallowCloneObject(target);
-    }
-
-    return {
-        ...target,
-        [key]: updated
-    };
-}
-
-function removeFromObject(
-    target: Record<string, unknown>,
-    pathSegments: readonly PathSegment[]
-): Record<string, unknown> {
-    const [head, ...tail] = pathSegments;
-
-    if (head === undefined) {
-        return shallowCloneObject(target);
-    }
-
-    const key = toKey(head);
-
-    if (!Object.hasOwn(target, key)) {
-        return shallowCloneObject(target);
-    }
-
-    if (tail.length === 0) {
-        return removeDirectKey(target, key);
-    }
-
-    return updateNestedKey(target, key, tail);
-}
-
-export function removePropertyAtPath(target: unknown, pathSegments: Path): unknown {
-    if (pathSegments.length === 0) {
-        return target;
-    }
-
-    if (Array.isArray(target)) {
-        return removeFromArray(target, pathSegments);
-    }
-
-    if (isRecord(target)) {
-        return removeFromObject(target, pathSegments);
-    }
-
-    return target;
-}
-
-function setValueInArray(target: readonly unknown[], pathSegments: Path, value: unknown): unknown[] {
+function updateArrayAtIndex(
+    target: readonly unknown[],
+    pathSegments: Path,
+    onTerminal: ArrayTerminal,
+    onRecurse: RecursiveStep
+): unknown[] {
     const [head, ...tail] = pathSegments;
     const index = typeof head === 'number' ? head : Number(head);
 
@@ -116,20 +48,37 @@ function setValueInArray(target: readonly unknown[], pathSegments: Path, value: 
     const copy = target.slice();
 
     if (tail.length === 0) {
-        copy[index] = value;
-        return copy;
+        return onTerminal(copy, index);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- ok for recursive call
-    copy[index] = setValueAtPath(copy[index], tail, value);
+    copy[index] = onRecurse(copy[index], tail);
     return copy;
 }
 
-// eslint-disable-next-line max-statements -- needs to be refactored
-function setValueInObject(
+function applyRecursiveObjectUpdate(
+    target: Record<string, unknown>,
+    key: string,
+    tail: Path,
+    onRecurse: RecursiveStep
+): Record<string, unknown> {
+    const current = target[key];
+    const updated = onRecurse(current, tail);
+
+    if (updated === current) {
+        return shallowCloneObject(target);
+    }
+
+    return {
+        ...target,
+        [key]: updated
+    };
+}
+
+function updateObjectAtKey(
     target: Record<string, unknown>,
     pathSegments: Path,
-    value: unknown
+    onTerminal: ObjectTerminal,
+    onRecurse: RecursiveStep
 ): Record<string, unknown> {
     const [head, ...tail] = pathSegments;
 
@@ -143,18 +92,35 @@ function setValueInObject(
         return shallowCloneObject(target);
     }
 
-    const current = target[key];
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- ok for recursive call
-    const updated = tail.length === 0 ? value : setValueAtPath(current, tail, value);
-
-    if (updated === current) {
-        return shallowCloneObject(target);
+    if (tail.length === 0) {
+        return onTerminal(target, key);
     }
 
-    return {
-        ...target,
-        [key]: updated
-    };
+    return applyRecursiveObjectUpdate(target, key, tail, onRecurse);
+}
+
+export function removePropertyAtPath(target: unknown, pathSegments: Path): unknown {
+    if (pathSegments.length === 0) {
+        return target;
+    }
+
+    if (Array.isArray(target)) {
+        return updateArrayAtIndex(
+            target,
+            pathSegments,
+            (copy, index) => {
+                copy.splice(index, 1);
+                return copy;
+            },
+            removePropertyAtPath
+        );
+    }
+
+    if (isRecord(target)) {
+        return updateObjectAtKey(target, pathSegments, removeDirectKey, removePropertyAtPath);
+    }
+
+    return target;
 }
 
 function createStructureForPath(pathSegments: Path, value: unknown): unknown {
@@ -165,9 +131,7 @@ function createStructureForPath(pathSegments: Path, value: unknown): unknown {
     }
 
     if (typeof head === 'number') {
-        const length = head + 1;
-        const result = Array.from<unknown>({ length });
-        result.fill(undefined, 0, length - 1);
+        const result = Array.from<unknown>({ length: head + 1 });
         result[head] = createStructureForPath(tail, value);
         return result;
     }
@@ -182,12 +146,31 @@ export function setValueAtPath(target: unknown, pathSegments: Path, value: unkno
         return value;
     }
 
+    const recurse: RecursiveStep = (child, tail) => {
+        return setValueAtPath(child, tail, value);
+    };
+
     if (Array.isArray(target)) {
-        return setValueInArray(target, pathSegments, value);
+        return updateArrayAtIndex(
+            target,
+            pathSegments,
+            (copy, index) => {
+                copy.splice(index, 1, value);
+                return copy;
+            },
+            recurse
+        );
     }
 
     if (isRecord(target)) {
-        return setValueInObject(target, pathSegments, value);
+        return updateObjectAtKey(
+            target,
+            pathSegments,
+            (record, key) => {
+                return { ...record, [key]: value };
+            },
+            recurse
+        );
     }
 
     return createStructureForPath(pathSegments, value);

--- a/source/record.ts
+++ b/source/record.ts
@@ -1,3 +1,3 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
- Share traversal between removePropertyAtPath and setValueAtPath via updateArrayAtIndex / updateObjectAtKey helpers; drop max-statements disable on setValueInObject.
- Collapse the three materialize*WithOverride ladders behind a single withMaterializedOverride helper.
- Split prepareOverrideValue into top-level and nested variants and extract mapRecordEntries; drop the nested boolean and the max-statements/complexity disable.
- Tighten normalizePath to only treat /^\d+$/ segments as array indices so 'foo.1abc.bar' no longer collapses to index 1.
- Broaden isRecord to Record<PropertyKey, unknown>, removing the symbol-cast helpers in isArrayFactoryValue, isOverrideWrapper, and isRemoveProperty.
- Drop no-op Array#fill in createStructureForPath.