### PR TITLE
Add buildInvalidWithAdditional factory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ Build an object with the property at `path` replaced by `value`, even if it brea
 const invalidAge = personFactory.buildInvalidWithChanged('age', 'unknown');
 ```
 
+### `factory.buildInvalidWithAdditional(path, value)`
+
+Build an object with an additional property added at `path`, useful for testing schemas that reject unknown fields. Throws if a property already exists at the given object path; for array paths, the value is splice-inserted at the given index.
+
+```ts
+const withExtra = personFactory.buildInvalidWithAdditional('nickname', 'Jay');
+```
+
 ## Prior art
 
 Objectory is heavily inspired by the excellent [`cooky-cutter`](https://github.com/skovy/cooky-cutter) and [`fishery`](https://github.com/thoughtbot/fishery) libraries — thank you for paving the way for ergonomic test data builders.

--- a/source/build-invalid-with-additional.test.ts
+++ b/source/build-invalid-with-additional.test.ts
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createFactory } from './main.ts';
+
+test('buildInvalidWithAdditional() adds a new top-level property', () => {
+    const factory = createFactory<{ name: string }>(() => {
+        return {
+            name: 'Alice'
+        };
+    });
+
+    const actual = factory.buildInvalidWithAdditional('extra', 'value');
+
+    assert.deepStrictEqual(actual, {
+        name: 'Alice',
+        extra: 'value'
+    });
+});
+
+test('buildInvalidWithAdditional() adds a nested property using dotted path', () => {
+    const factory = createFactory<{ profile: { name: string } }>(() => {
+        return {
+            profile: createFactory(() => {
+                return {
+                    name: 'Alice'
+                };
+            })
+        };
+    });
+
+    const actual = factory.buildInvalidWithAdditional('profile.extra', 'value');
+
+    assert.deepStrictEqual(actual, {
+        profile: {
+            name: 'Alice',
+            extra: 'value'
+        }
+    });
+});
+
+test('buildInvalidWithAdditional() splice-inserts into arrays at index', () => {
+    const factory = createFactory<{ values: number[] }>(() => {
+        return {
+            values: [-1, 1]
+        };
+    });
+
+    const actual = factory.buildInvalidWithAdditional('values.1', 0);
+
+    assert.deepStrictEqual(actual, {
+        values: [-1, 0, 1]
+    });
+});
+
+test('buildInvalidWithAdditional() throws when the property already exists', () => {
+    const factory = createFactory<{ name: string }>(() => {
+        return {
+            name: 'Alice'
+        };
+    });
+
+    assert.throws(() => {
+        return factory.buildInvalidWithAdditional('name', 'other');
+    }, /already exists/u);
+});
+
+test('buildInvalidWithAdditional() leaves original defaults untouched', () => {
+    const factory = createFactory<{ flag: boolean }>(() => {
+        return {
+            flag: false
+        };
+    });
+
+    const modified = factory.buildInvalidWithAdditional('extra', 'value');
+    const original = factory.build();
+
+    assert.deepStrictEqual(modified, { flag: false, extra: 'value' });
+    assert.deepStrictEqual(original, { flag: false });
+});

--- a/source/main.ts
+++ b/source/main.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @stylistic/indent-binary-ops, @stylistic/operator-linebreak, @stylistic/indent -- conflicts with prettier */
-import { normalizePath, removePropertyAtPath, setValueAtPath } from './path-operations.ts';
+import { addValueAtPath, normalizePath, removePropertyAtPath, setValueAtPath } from './path-operations.ts';
 import { isRecord } from './record.ts';
 
 const arrayFactorySymbol: unique symbol = Symbol('objectory.arrayFactory');
@@ -51,6 +51,7 @@ export type ObjectoryFactory<ObjectShape extends Record<string, AllowedObjectSha
     readonly buildList: (options?: { readonly length?: number }) => ObjectShape[];
     readonly buildInvalidWithout: (path: string) => unknown;
     readonly buildInvalidWithChanged: (path: string, value: unknown) => unknown;
+    readonly buildInvalidWithAdditional: (path: string, value: unknown) => unknown;
 };
 
 export type ShapeToGeneratorReturnValueHelper<T> = T extends readonly (infer U)[]
@@ -529,6 +530,16 @@ function instantiateFactory<ObjectShape extends Record<string, AllowedObjectShap
             const baseObject = factory.build();
 
             return setValueAtPath(baseObject, pathSegments, newValue);
+        },
+        buildInvalidWithAdditional(path, additionalValue) {
+            const pathSegments = normalizePath(path);
+            const baseObject = factory.build();
+
+            if (pathSegments.length === 0) {
+                return baseObject;
+            }
+
+            return addValueAtPath(baseObject, pathSegments, additionalValue);
         }
     };
 

--- a/source/path-operations.test.ts
+++ b/source/path-operations.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { normalizePath, removePropertyAtPath, setValueAtPath } from './path-operations.ts';
+import { addValueAtPath, normalizePath, removePropertyAtPath, setValueAtPath } from './path-operations.ts';
 
 test('normalizePath() splits dotted strings into segments', () => {
     assert.deepStrictEqual(normalizePath('foo.bar.baz'), ['foo', 'bar', 'baz']);
@@ -97,4 +97,82 @@ test('setValueAtPath() updates array indices', () => {
     assert.deepStrictEqual(result, {
         values: [-1, 'not-a-number', 1]
     });
+});
+
+test('addValueAtPath() adds a new top-level property immutably', () => {
+    const original = { foo: 'value' } as const;
+
+    const result = addValueAtPath(original, ['extra'], 'new');
+
+    assert.deepStrictEqual(result, { foo: 'value', extra: 'new' });
+    assert.deepStrictEqual(original, { foo: 'value' });
+});
+
+test('addValueAtPath() adds a nested property', () => {
+    const original = {
+        outer: {
+            inner: { keep: 'stay' }
+        }
+    } as const;
+
+    const result = addValueAtPath(original, ['outer', 'inner', 'extra'], 'new');
+
+    assert.deepStrictEqual(result, {
+        outer: {
+            inner: { keep: 'stay', extra: 'new' }
+        }
+    });
+});
+
+test('addValueAtPath() splice-inserts into arrays at index', () => {
+    const original = {
+        values: [-1, 1]
+    } as const;
+
+    const result = addValueAtPath(original, ['values', 1], 0);
+
+    assert.deepStrictEqual(result, {
+        values: [-1, 0, 1]
+    });
+});
+
+test('addValueAtPath() appends to arrays when index equals length', () => {
+    const original = {
+        values: [-1, 0]
+    } as const;
+
+    const result = addValueAtPath(original, ['values', original.values.length], 1);
+
+    assert.deepStrictEqual(result, {
+        values: [-1, 0, 1]
+    });
+});
+
+test('addValueAtPath() leaves arrays untouched when index is out of range', () => {
+    const original = {
+        values: [-1, 0]
+    } as const;
+    const outOfRangeIndex = original.values.length + 1;
+
+    const result = addValueAtPath(original, ['values', outOfRangeIndex], 1);
+
+    assert.deepStrictEqual(result, {
+        values: [-1, 0]
+    });
+});
+
+test('addValueAtPath() throws when the target object key already exists', () => {
+    const original = { foo: 'value' } as const;
+
+    assert.throws(() => {
+        return addValueAtPath(original, ['foo'], 'other');
+    }, /already exists/u);
+});
+
+test('addValueAtPath() leaves value untouched when parent path is missing', () => {
+    const original = { outer: { inner: { keep: 'stay' } } } as const;
+
+    const result = addValueAtPath(original, ['outer', 'missing', 'extra'], 'new');
+
+    assert.deepStrictEqual(result, { outer: { inner: { keep: 'stay' } } });
 });

--- a/source/path-operations.ts
+++ b/source/path-operations.ts
@@ -175,3 +175,101 @@ export function setValueAtPath(target: unknown, pathSegments: Path, value: unkno
 
     return createStructureForPath(pathSegments, value);
 }
+
+function spliceInsertAtIndex(target: readonly unknown[], index: number, value: unknown): unknown[] {
+    if (index > target.length) {
+        return target.slice();
+    }
+
+    const copy = target.slice();
+    copy.splice(index, 0, value);
+    return copy;
+}
+
+function addNewKeyOrThrow(target: Record<string, unknown>, key: string, value: unknown): Record<string, unknown> {
+    if (Object.hasOwn(target, key)) {
+        throw new Error(`Cannot add property at path "${key}" because it already exists`);
+    }
+
+    return { ...target, [key]: value };
+}
+
+function recurseIntoArrayElement(
+    target: readonly unknown[],
+    index: number,
+    tail: Path,
+    onRecurse: RecursiveStep
+): unknown[] {
+    if (index >= target.length) {
+        return target.slice();
+    }
+
+    const copy = target.slice();
+    copy[index] = onRecurse(copy[index], tail);
+    return copy;
+}
+
+function addValueAtArrayPath(
+    target: readonly unknown[],
+    pathSegments: Path,
+    value: unknown,
+    onRecurse: RecursiveStep
+): unknown[] {
+    const [head, ...tail] = pathSegments;
+    const index = typeof head === 'number' ? head : Number(head);
+
+    if (!Number.isInteger(index) || index < 0) {
+        return target.slice();
+    }
+
+    if (tail.length === 0) {
+        return spliceInsertAtIndex(target, index, value);
+    }
+
+    return recurseIntoArrayElement(target, index, tail, onRecurse);
+}
+
+function addValueAtObjectPath(
+    target: Record<string, unknown>,
+    pathSegments: Path,
+    value: unknown,
+    onRecurse: RecursiveStep
+): Record<string, unknown> {
+    const [head, ...tail] = pathSegments;
+
+    if (head === undefined) {
+        return shallowCloneObject(target);
+    }
+
+    const key = toKey(head);
+
+    if (tail.length === 0) {
+        return addNewKeyOrThrow(target, key, value);
+    }
+
+    if (!Object.hasOwn(target, key)) {
+        return shallowCloneObject(target);
+    }
+
+    return applyRecursiveObjectUpdate(target, key, tail, onRecurse);
+}
+
+export function addValueAtPath(target: unknown, pathSegments: Path, value: unknown): unknown {
+    if (pathSegments.length === 0) {
+        return target;
+    }
+
+    const recurse: RecursiveStep = (child, tail) => {
+        return addValueAtPath(child, tail, value);
+    };
+
+    if (Array.isArray(target)) {
+        return addValueAtArrayPath(target, pathSegments, value, recurse);
+    }
+
+    if (isRecord(target)) {
+        return addValueAtObjectPath(target, pathSegments, value, recurse);
+    }
+
+    return target;
+}


### PR DESCRIPTION
Symmetric with buildInvalidWithout and buildInvalidWithChanged, used for negative tests that need an extra property at a given path. Object leaf collisions throw; array leaves splice-insert at the index.