### PR TITLE
Compile sources before evaluating the release gate

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,5 +23,5 @@ packtory-dry-run: compile
 packtory-publish: compile
 	packtory publish --no-dry-run
 
-release-gate:
+release-gate: compile
 	github-release-gate


### PR DESCRIPTION
The `release-gate` recipe runs `github-release-gate`, which evaluates `packtory.config.js`. That config points at the compiled bundle `target/build/source/main.js`, but the `evaluate-gate` publish job never compiled the sources, so the gate failed with `ENOENT: no such file or directory, open 'target/build/source/main.js'`. Depending on `compile` (like the sibling `packtory-dry-run` and `packtory-publish` recipes) makes the bundle exist before the gate runs.