### PR TITLE
Configure Renovate to use `merge-commit` automerge strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,11 @@
 {
-    "extends": ["config:base"],
+    "extends": [
+        "config:base"
+    ],
     "commitMessagePrefix": "⬆️ ",
-    "labels": ["renovate"],
+    "labels": [
+        "renovate"
+    ],
     "dependencyDashboard": false,
     "rebaseStalePrs": true,
     "automerge": true,
@@ -12,9 +16,13 @@
     },
     "packageRules": [
         {
-            "matchPackagePatterns": ["^@enormora/eslint-config"],
+            "matchPackagePatterns": [
+                "^@enormora/eslint-config"
+            ],
             "groupName": "@enormora/eslint-config",
             "groupSlug": "enormora-eslint-config"
         }
-    ]
+    ],
+    "platformAutomerge": true,
+    "automergeStrategy": "merge-commit"
 }


### PR DESCRIPTION
Configures Renovate to use `merge-commit` explicitly while keeping `platformAutomerge` enabled for the repository merge queue path.