### PR TITLE
Document discriminated-union factory patterns in the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,53 @@ const trip = tripFactory.build({
 });
 ```
 
+## Discriminated unions
+
+For a union of object types distinguished by a discriminator, there are two complementary shapes. Which one you reach for depends on whether a given test wants a fixed variant or any member of the union.
+
+Build a factory fixed to one variant by typing it to that variant. The discriminator is an ordinary field with a literal default:
+
+```ts
+type GetRequest = { method: 'GET'; url: string; retries: number; };
+type PostRequest = { method: 'POST'; url: string; retries: number; body: string; };
+type HttpRequest = GetRequest | PostRequest;
+
+const getRequestFactory = createFactory<GetRequest>(() => ({
+    method: 'GET',
+    url: 'https://example.com',
+    retries: 3
+}));
+```
+
+Build a factory for the whole union by typing it to the union. The generator returns any one variant, and `build()` returns the union type. Overrides can reshape the built variant but cannot switch it to another one:
+
+```ts
+const httpRequestFactory = createFactory<HttpRequest>(() => ({
+    method: 'GET',
+    url: 'https://example.com',
+    retries: 3
+}));
+```
+
+To share the fields common to every variant, build a factory for the common part and derive each variant with `extend`, adding that variant's discriminator and extra fields. The variants reuse the common defaults, and nested shared factories stay overridable at any depth:
+
+```ts
+type CommonFields = { url: string; retries: number; };
+type GetRequest = CommonFields & { method: 'GET'; };
+type PostRequest = CommonFields & { method: 'POST'; body: string; };
+
+const commonRequestFactory = createFactory<CommonFields>(() => ({
+    url: 'https://example.com',
+    retries: 3
+}));
+
+const getRequestFactory = commonRequestFactory.extend<GetRequest>(() => ({ method: 'GET' }));
+const postRequestFactory = commonRequestFactory.extend<PostRequest>(() => ({
+    method: 'POST',
+    body: '{}'
+}));
+```
+
 ## API
 
 ### `createFactory(generator)`


### PR DESCRIPTION
Documents the three shapes for building discriminated unions with objectory: a factory fixed to one variant (`createFactory<Variant>`), a factory for the whole union, and sharing the common fields by extending a common base factory with `extend`.

This closes the perceived gap around "narrowing" a factory: a fixed-variant factory is simply `createFactory` typed to that variant, and cross-variant reuse is already expressible with `extend`, so no new API is added. All snippets were type-checked and executed against the current implementation.