### PR TITLE
Reorder `README` so the API reference precedes the recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,86 +32,6 @@ const crew = personFactory.buildList({ length: 3 });
 
 Objectory handles deeply nested factories, arrays, and targeted overrides so you can focus on the behaviours under test instead of wiring up objects.
 
-## Nested factories
-
-```ts
-type Passenger = {
-    name: string;
-    age: number;
-};
-
-const passengerFactory = createFactory<Passenger>(() => {
-    return {
-        name: 'Jane Doe',
-        age: 32
-    };
-});
-
-type Trip = {
-    driver: Passenger;
-    passengers: readonly Passenger[];
-};
-
-const tripFactory = createFactory<Trip>(() => {
-    return {
-        driver: passengerFactory,
-        passengers: passengerFactory.asArray({ length: 2 })
-    };
-});
-
-const trip = tripFactory.build({
-    driver: { name: 'Alex' },
-    passengers: [ { age: 40 } ]
-});
-```
-
-## Discriminated unions
-
-For a union of object types distinguished by a discriminator, there are two complementary shapes. Which one you reach for depends on whether a given test wants a fixed variant or any member of the union.
-
-Build a factory fixed to one variant by typing it to that variant. The discriminator is an ordinary field with a literal default:
-
-```ts
-type GetRequest = { method: 'GET'; url: string; retries: number; };
-type PostRequest = { method: 'POST'; url: string; retries: number; body: string; };
-type HttpRequest = GetRequest | PostRequest;
-
-const getRequestFactory = createFactory<GetRequest>(() => ({
-    method: 'GET',
-    url: 'https://example.com',
-    retries: 3
-}));
-```
-
-Build a factory for the whole union by typing it to the union. The generator returns any one variant, and `build()` returns the union type. Overrides can reshape the built variant but cannot switch it to another one:
-
-```ts
-const httpRequestFactory = createFactory<HttpRequest>(() => ({
-    method: 'GET',
-    url: 'https://example.com',
-    retries: 3
-}));
-```
-
-To share the fields common to every variant, build a factory for the common part and derive each variant with `extend`, adding that variant's discriminator and extra fields. The variants reuse the common defaults, and nested shared factories stay overridable at any depth:
-
-```ts
-type CommonFields = { url: string; retries: number; };
-type GetRequest = CommonFields & { method: 'GET'; };
-type PostRequest = CommonFields & { method: 'POST'; body: string; };
-
-const commonRequestFactory = createFactory<CommonFields>(() => ({
-    url: 'https://example.com',
-    retries: 3
-}));
-
-const getRequestFactory = commonRequestFactory.extend<GetRequest>(() => ({ method: 'GET' }));
-const postRequestFactory = commonRequestFactory.extend<PostRequest>(() => ({
-    method: 'POST',
-    body: '{}'
-}));
-```
-
 ## API
 
 ### `createFactory(generator)`
@@ -206,6 +126,90 @@ Build an object with an additional property added at `path`, useful for testing 
 
 ```ts
 const withExtra = personFactory.buildInvalidWithAdditional('nickname', 'Jay');
+```
+
+## Recipes
+
+Compositional patterns built from the methods above.
+
+### Nested factories
+
+```ts
+type Passenger = {
+    name: string;
+    age: number;
+};
+
+const passengerFactory = createFactory<Passenger>(() => {
+    return {
+        name: 'Jane Doe',
+        age: 32
+    };
+});
+
+type Trip = {
+    driver: Passenger;
+    passengers: readonly Passenger[];
+};
+
+const tripFactory = createFactory<Trip>(() => {
+    return {
+        driver: passengerFactory,
+        passengers: passengerFactory.asArray({ length: 2 })
+    };
+});
+
+const trip = tripFactory.build({
+    driver: { name: 'Alex' },
+    passengers: [ { age: 40 } ]
+});
+```
+
+### Discriminated unions
+
+For a union of object types distinguished by a discriminator, there are two complementary shapes. Which one you reach for depends on whether a given test wants a fixed variant or any member of the union.
+
+Build a factory fixed to one variant by typing it to that variant. The discriminator is an ordinary field with a literal default:
+
+```ts
+type GetRequest = { method: 'GET'; url: string; retries: number; };
+type PostRequest = { method: 'POST'; url: string; retries: number; body: string; };
+type HttpRequest = GetRequest | PostRequest;
+
+const getRequestFactory = createFactory<GetRequest>(() => ({
+    method: 'GET',
+    url: 'https://example.com',
+    retries: 3
+}));
+```
+
+Build a factory for the whole union by typing it to the union. The generator returns any one variant, and `build()` returns the union type. Overrides can reshape the built variant but cannot switch it to another one:
+
+```ts
+const httpRequestFactory = createFactory<HttpRequest>(() => ({
+    method: 'GET',
+    url: 'https://example.com',
+    retries: 3
+}));
+```
+
+To share the fields common to every variant, build a factory for the common part and derive each variant with `extend`, adding that variant's discriminator and extra fields. The variants reuse the common defaults, and nested shared factories stay overridable at any depth:
+
+```ts
+type CommonFields = { url: string; retries: number; };
+type GetRequest = CommonFields & { method: 'GET'; };
+type PostRequest = CommonFields & { method: 'POST'; body: string; };
+
+const commonRequestFactory = createFactory<CommonFields>(() => ({
+    url: 'https://example.com',
+    retries: 3
+}));
+
+const getRequestFactory = commonRequestFactory.extend<GetRequest>(() => ({ method: 'GET' }));
+const postRequestFactory = commonRequestFactory.extend<PostRequest>(() => ({
+    method: 'POST',
+    body: '{}'
+}));
 ```
 
 ## Prior art


### PR DESCRIPTION
Moves the API section directly after Quick start, and relocates the nested-factory and discriminated-union examples into a new Recipes section after it. Previously those compositional examples appeared before the methods they rely on were introduced, so a first-time reader met `asArray`, nested factories, and `extend`-based composition before seeing what those methods do.

Section-move only: the code snippets are unchanged, aside from demoting the two moved headings to `###` under Recipes.